### PR TITLE
v1.0.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggd
 Type: Package
 Title: Gradational Gaussian Distribution Reference Class
-Version: 1.0.3
+Version: 1.0.3.1
 Authors@R: c(
     person( given   = "Kimitsuna",
             family  = "Ura",

--- a/R/ggd.1.R
+++ b/R/ggd.1.R
@@ -1404,6 +1404,7 @@ GGD$methods(
 #' @param   x           A vector of x-coordinates.
 #' @return  The values of the probability density function for the given x-coordinates.
 #' @importFrom  stats   dnorm pnorm
+#' @seealso \code{\link[ggd]{p}}, \code{\link[ggd]{q}}, \code{\link[ggd]{r}}
 #' @examples
 #'  a <- GGD$new()
 #'  a$trace.q(
@@ -1484,6 +1485,7 @@ GGD$methods(
 #' @return  A vector of the probabilities of that a value of the random variable is less than
 #'          or equal to given x-coordinates.
 #' @importFrom  stats       pnorm
+#' @seealso \code{\link[ggd]{d}}, \code{\link[ggd]{q}}, \code{\link[ggd]{r}}
 #' @examples
 #'  a <- GGD$new()
 #'  a$trace.q(
@@ -1561,6 +1563,7 @@ GGD$methods(
 #' @return  A vector of the x-coordinates with the cumulative distribution function
 #'          is equal to the given probabilities in the tolerance level.
 #' @importFrom  stats       qnorm
+#' @seealso \code{\link[ggd]{d}}, \code{\link[ggd]{p}}, \code{\link[ggd]{r}}
 #' @examples
 #'  a <- GGD$new()
 #'  a$trace.q(
@@ -1749,6 +1752,7 @@ GGD$methods(
 #' @param   tol     The tolerance level for the convergence criterion for
 #'                  \code{\link[ggd]{q}} method.
 #' @return  A vector of random numbers.
+#' @seealso \code{\link[ggd]{d}}, \code{\link[ggd]{p}}, \code{\link[ggd]{q}}
 #' @examples
 #'  a <- GGD$new()
 #'  a$trace.q(

--- a/R/ggd.nls.freq.R
+++ b/R/ggd.nls.freq.R
@@ -231,11 +231,11 @@
 #'                      It is equivalent to \code{kind} argument of \code{ggd.nls.freq}.
 #'
 #'                      When this method is called without \code{this.kind} argument
-#'                      or other conditions, it attempt to retain the value of
-#'                      \code{mix.type} field as much as possible except for \code{kind} field,
-#'                      i.e., the condition whether the mean value and standard deviation of
-#'                      each component are aligned to same values or not may not be retained.
-#'                      If you want to retain these conditions as well,
+#'                      or other conditions, it attempts to retain the value of
+#'                      \code{mix.type} field as much as possible, but not \code{kind} field.
+#'                      That is, the condition that the mean values or standard deviations
+#'                      of the components are aligned to the same values or not
+#'                      may not be retained. If you want to retain the condition as well,
 #'                      indicate the object itself to \code{this.kind} argument like as
 #'                      \code{obj$nls.freq(data, this.kind = obj)}.
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,14 @@
-── R CMD check results ────────────────────────────────────── ggd 1.0.3 ────
-Duration: 16m 23.2s
+── R CMD check results ──────────────────────────────────── ggd 1.0.3.1 ────
+Duration: 16m 45.4s
 
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
-── ggd 1.0.3: NOTE
+── ggd 1.0.3.1: NOTE
 
-  Build ID:   ggd_1.0.3.tar.gz-3f4268ebdde1490d81f021c940310135
+  Build ID:   ggd_1.0.3.1.tar.gz-99d0690e152d4e7cac299f044a2ed8ff
   Platform:   Windows Server 2022, R-devel, 64 bit
-  Submitted:  2h 10m 2.7s ago
-  Build time: 30m 52.7s
+  Submitted:  47m 16.1s ago
+  Build time: 30m 38.5s
 
 ❯ checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Kimitsuna Ura <kimitsuna@i.softbank.jp>'
@@ -28,40 +28,40 @@ Duration: 16m 23.2s
 
 0 errors ✔ | 0 warnings ✔ | 4 notes ✖
 
-── ggd 1.0.3: NOTE
+── ggd 1.0.3.1: NOTE
 
-  Build ID:   ggd_1.0.3.tar.gz-de5e1af3d4a6471e9125682a94a1d72e
+  Build ID:   ggd_1.0.3.1.tar.gz-18b001e039e14923b2dae0deb0a5a7c5
   Platform:   Ubuntu Linux 20.04.1 LTS, R-release, GCC
-  Submitted:  2h 10m 2.8s ago
-  Build time: 40m 21.4s
+  Submitted:  47m 16.2s ago
+  Build time: 38m 17.6s
 
-❯ checking CRAN incoming feasibility ... [6s/23s] NOTE
+❯ checking CRAN incoming feasibility ... [6s/19s] NOTE
   Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
   
   New submission
 
-❯ checking examples ... [13s/34s] NOTE
+❯ checking examples ... [13s/31s] NOTE
   Examples with CPU (user + system) or elapsed time > 5s
                     user system elapsed
-  ggd.nls.freq.all 3.128  0.004   8.376
+  ggd.nls.freq.all 3.073      0   6.968
 
 0 errors ✔ | 0 warnings ✔ | 2 notes ✖
 
-── ggd 1.0.3: NOTE
+── ggd 1.0.3.1: NOTE
 
-  Build ID:   ggd_1.0.3.tar.gz-e0135eb74fab4cc6a60d64951a924881
+  Build ID:   ggd_1.0.3.1.tar.gz-d9ac4f179cad4ff29ec454f19e45df79
   Platform:   Fedora Linux, R-devel, clang, gfortran
-  Submitted:  2h 10m 2.8s ago
-  Build time: 39m 49.1s
+  Submitted:  47m 16.2s ago
+  Build time: 37m 50s
 
-❯ checking CRAN incoming feasibility ... [6s/25s] NOTE
+❯ checking CRAN incoming feasibility ... [6s/22s] NOTE
   Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
   
   New submission
 
-❯ checking examples ... [14s/37s] NOTE
+❯ checking examples ... [14s/31s] NOTE
   Examples with CPU (user + system) or elapsed time > 5s
                     user system elapsed
-  ggd.nls.freq.all 3.281  0.007   9.271
+  ggd.nls.freq.all 3.118      0   7.012
 
 0 errors ✔ | 0 warnings ✔ | 2 notes ✖

--- a/man/d.Rd
+++ b/man/d.Rd
@@ -25,3 +25,6 @@ This method works like \code{\link[stats]{dnorm}} for a normal distribution.
  a$d( c( -0.67, 0, 0.53 ) )
  plot( seq( -3, 3, 0.01 ), a$d( seq( -3, 3, 0.01 ) ), type = "l" )
 }
+\seealso{
+\code{\link[ggd]{p}}, \code{\link[ggd]{q}}, \code{\link[ggd]{r}}
+}

--- a/man/nls.freq.Rd
+++ b/man/nls.freq.Rd
@@ -213,11 +213,11 @@ See 'Arguments' of \code{\link[stats]{nls}} for more information.}
                      It is equivalent to \code{kind} argument of \code{ggd.nls.freq}.
 
                      When this method is called without \code{this.kind} argument
-                     or other conditions, it attempt to retain the value of
-                     \code{mix.type} field as much as possible except for \code{kind} field,
-                     i.e., the condition whether the mean value and standard deviation of
-                     each component are aligned to same values or not may not be retained.
-                     If you want to retain these conditions as well,
+                     or other conditions, it attempts to retain the value of
+                     \code{mix.type} field as much as possible, but not \code{kind} field.
+                     That is, the condition that the mean values or standard deviations
+                     of the components are aligned to the same values or not
+                     may not be retained. If you want to retain the condition as well,
                      indicate the object itself to \code{this.kind} argument like as
                      \code{obj$nls.freq(data, this.kind = obj)}.}
 

--- a/man/p.Rd
+++ b/man/p.Rd
@@ -27,3 +27,6 @@ This method works like \code{\link[stats]{pnorm}} for a normal distribution.
  a$p( c( -0.67, 0, 0.53 ) )
  plot( seq( -3, 3, 0.01 ), a$p( seq( -3, 3, 0.01 ) ), type = "l" )
 }
+\seealso{
+\code{\link[ggd]{d}}, \code{\link[ggd]{q}}, \code{\link[ggd]{r}}
+}

--- a/man/q.Rd
+++ b/man/q.Rd
@@ -29,3 +29,6 @@ This method works like \code{\link[stats]{qnorm}} for a normal distribution.
  a$q( c( 0.25, 0.5, 0.75 ) )
  plot( seq( 0, 1, 0.01 ), a$q( seq( 0, 1, 0.01 ) ), type = "l" )
 }
+\seealso{
+\code{\link[ggd]{d}}, \code{\link[ggd]{p}}, \code{\link[ggd]{r}}
+}

--- a/man/r.Rd
+++ b/man/r.Rd
@@ -29,3 +29,6 @@ This method calls \code{\link[ggd]{q}} method internally.
      this.mix.type = 2 )
  hist( a$r( 400 ) )
 }
+\seealso{
+\code{\link[ggd]{d}}, \code{\link[ggd]{p}}, \code{\link[ggd]{q}}
+}


### PR DESCRIPTION
+ d(), p(), q() and r() methods references each other at 'See also'.
+ At nls.freq manual, description about this.kind argument is revised.