### PR TITLE
v1.0.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggd
 Type: Package
 Title: Gradational Gaussian Distribution Reference Class
-Version: 1.0.3.2
+Version: 1.0.4
 Authors@R: c(
     person( given   = "Kimitsuna",
             family  = "Ura",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggd
 Type: Package
 Title: Gradational Gaussian Distribution Reference Class
-Version: 1.0.3.1
+Version: 1.0.3.2
 Authors@R: c(
     person( given   = "Kimitsuna",
             family  = "Ura",

--- a/R/ggd.1.R
+++ b/R/ggd.1.R
@@ -55,41 +55,79 @@ f.t3.p <- list( function( x, m, s )
 #' The class provides the Gradational Gaussian Distribution.
 #' @export      GGD
 #' @exportClass GGD
-#' @field   kind.index      An integer; the index number of the kind of the distribution model.
-#' @field   kind            A string; the name of the kind of the distribution model.
+#' @field   kind.index      An integer; the number indicating the kind of distribution model.
+#'                          That is, the index number for the value of \code{kind} field.
+#' @field   kind            A character string; the name of the kind of the distribution model.
+#'
+#'          \code{kind} shows the classification of each of the 6 distribution models
+#'          shown in 'Details', subdivided (except for the normal distribution)
+#'          into 3 categories based on whether the mean values or standard deviations
+#'          of the components are all equal or not.
+#'          Therefore, there are 16 (= 5 x 3 + 1) \code{kind}s in this package defined in
+#'          \code{ggd:::kinds} as follows.
+#'
+#'          \tabular{clc}{
+#'              Index \tab Distribution model (\code{kind}) \cr
+#'              \code{1}  \tab Normal distribution \cr
+#'              \code{2}  \tab
+#'                  Mean of Mean-Differed Sigma-Equaled 2 Normal Distributions \cr
+#'              \code{3}  \tab Mean of Mean-Equaled Sigma-Differed " \cr
+#'              \code{4}  \tab Mean of Mean-Differed Sigma-Differed " \cr
+#'              \code{5}  \tab
+#'                  Mean-Differed Sigma-Equaled Horizontal Gradational Distribution \cr
+#'              \code{6}  \tab Mean-Equaled Sigma-Differed " \cr
+#'              \code{7}  \tab Mean-Differed Sigma-Differed " \cr
+#'              \code{8}  \tab
+#'                  2-Mean-Differed Sigma-Equaled Vertical Gradational Distribution \cr
+#'              \code{9}  \tab 2-Mean-Equaled Sigma-Differed " \cr
+#'              \code{10} \tab 2-Mean-Differed Sigma-Differed " \cr
+#'              \code{11} \tab 3-Mean-Differed Sigma-Equaled " \cr
+#'              \code{12} \tab 3-Mean-Equaled Sigma-Differed " \cr
+#'              \code{13} \tab 3-Mean-Differed Sigma-Differed " \cr
+#'              \code{14} \tab
+#'                  Mean-Differed Sigma-Equaled Horizontal-Vertical Gradational Distribution \cr
+#'              \code{15} \tab Mean-Equaled Sigma-Differed " \cr
+#'              \code{16} \tab Mean-Differed Sigma-Differed " \cr
+#'          }
+#'
+#'          \code{kind.index} and \code{kind} fields represent how the object actually
+#'          behaves as a distribution model. These fields are closely related to the number
+#'          of components (normal distributions) of the object and how they are mixed,
+#'          but are not entirely dependent on them.
+#'          For example, if a object with \code{mix.type = 1} (mean of 2 normal distributions)
+#'          has two same normal distributions as the components,
+#'          the object will actually behave as a normal distribution.
+#'          In this case, \code{kind.index} and \code{kind} fields indicate
+#'          \code{"Normal Distribution"} rather than \code{"Mean of 2 Normal Distributions"}.
+#'
 #' @field   mix.type        An integer which represents how to mix normal distributions
 #'                          of the components.
 #'
-#'                          The type of the distribution model and the number of rows
-#'                          in \code{cmp} field will be as follows with this value:
-#'                          \itemize{
-#'                              \item \code{0} : Normal distribution.
-#'                                        \code{cmp} has only 1 row.
-#'                              \item \code{1} : Mean of 2 normal distributions.
-#'                                        \code{cmp} has 2 rows.
-#'                              \item \code{2} : Horizontal gradational distribution.
-#'                                        \code{cmp} has 2 rows.
-#'                              \item \code{3} : Vertical gradational distribution.
-#'                                        \code{cmp} has 2 or 3 rows.
-#'                              \item \code{4} : Horizontal-vertical gradational distribution.
-#'                                               \code{cmp} has 4 rows.
-#'                          }
+#'          The type of the distribution model and the number of components,
+#'          which equals the number of rows in \code{cmp} field, will be as follows.
 #'
-#'                          The distribution model of \code{mix.type = 1} is not
-#'                          a gradational Gaussian distribution (GGD), but a kind of
-#'                          Gaussian mixture model (GMM).
-#'                          This is provided for comparing GGD with GMM.
+#'          \tabular{clc}{
+#'              \code{mix.type} \tab Distribution model          \tab Number of components \cr
+#'              \code{0}        \tab Normal distribution                            \tab 1 \cr
+#'              \code{1}        \tab Mean of 2 normal distributions                 \tab 2 \cr
+#'              \code{2}        \tab Horizontal gradational distribution (default)  \tab 2 \cr
+#'              \code{3}        \tab Vertical gradational distribution          \tab 2 or 3 \cr
+#'              \code{4}        \tab Horizontal-vertical gradational distribution   \tab 4
+#'          }
+#'
+#'          The distribution model of \code{mix.type = 1} is not
+#'          a gradational Gaussian distribution (GGD), but a kind of
+#'          Gaussian mixture model (GMM). This is provided for comparing GGD with GMM.
 #'
 #' @field   cmp             A data frame with 2 numeric columns which have
 #'                          the parameters of the normal distributions of the components.
 #'
-#'                          \code{mean} column represents the mean values of the components,
-#'                          and \code{sd} column represents the standard deviations.
+#'          \code{mean} column represents the mean values of the components,
+#'          and \code{sd} column represents the standard deviations.
 #'
-#'                          Where \code{mix.type} is from \code{0} to \code{3},
-#'                          it has 1 to 3 rows named like \code{"n.i"}.
-#'                          Where \code{mix.type = 4},
-#'                          it has 4 rows named like \code{"n.i.j"}.
+#'          Where \code{mix.type} is from \code{0} to \code{3},
+#'          it has 1 to 3 rows named like \code{"n.i"}.
+#'          Where \code{mix.type = 4}, it has 4 rows named like \code{"n.i.j"}.
 #'
 #' @field   median          A numeric; the median of the distribution.
 #' @field   mean            A numeric; the mean of the distribution.
@@ -101,11 +139,10 @@ f.t3.p <- list( function( x, m, s )
 #' @field   usd.abs.error   A numeric;
 #'                          the estimated modulus of the absolute error for \code{usd}.
 #'
-#'                          Where \code{mix.type = 4}, to compute the half standard deviations,
-#'                          \code{\link[stats]{integrate}} function is used.
-#'                          And the modulus of the absolute errors which
-#'                          \code{\link[stats]{integrate}} function has reported
-#'                          will be set into these \code{*.abs.error} fields.
+#'          Where \code{mix.type = 4}, to compute the half standard deviations,
+#'          \code{\link[stats]{integrate}} function is used.
+#'          And the modulus of the absolute errors which \code{\link[stats]{integrate}}
+#'          function has reported will be set into these \code{*.abs.error} fields.
 #'
 #' @seealso \code{\link[ggd]{set.cmp}},
 #'          \code{\link[ggd]{nls.freq}}, \code{\link[ggd]{ggd.nls.freq.all}},
@@ -641,8 +678,10 @@ GGD$methods(
 #'                      distribution model.
 #'
 #'                      Each element must be a character string of a regular expression pattern
-#'                      matching to an element of \code{ggd:::kinds} or an index number of
-#'                      \code{ggd:::kinds}, or a \code{\link[ggd]{GGD}} object, or an \code{NA}.
+#'                      matching to an element of \code{ggd:::kinds}
+#'                      (see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}})
+#'                      or an index number of \code{ggd:::kinds},
+#'                      or a \code{\link[ggd]{GGD}} object, or an \code{NA}.
 #'
 #'                      If a character string is indicated as an element,
 #'                      the string matches only one element of \code{ggd:::kinds} of

--- a/R/ggd.1.R
+++ b/R/ggd.1.R
@@ -68,7 +68,7 @@ f.t3.p <- list( function( x, m, s )
 #'
 #'          \tabular{clc}{
 #'              Index \tab Distribution model (\code{kind}) \cr
-#'              \code{1}  \tab Normal distribution \cr
+#'              \code{1}  \tab Normal Distribution \cr
 #'              \code{2}  \tab
 #'                  Mean of Mean-Differed Sigma-Equaled 2 Normal Distributions \cr
 #'              \code{3}  \tab Mean of Mean-Equaled Sigma-Differed " \cr
@@ -87,7 +87,7 @@ f.t3.p <- list( function( x, m, s )
 #'              \code{14} \tab
 #'                  Mean-Differed Sigma-Equaled Horizontal-Vertical Gradational Distribution \cr
 #'              \code{15} \tab Mean-Equaled Sigma-Differed " \cr
-#'              \code{16} \tab Mean-Differed Sigma-Differed " \cr
+#'              \code{16} \tab Mean-Differed Sigma-Differed "
 #'          }
 #'
 #'          \code{kind.index} and \code{kind} fields represent how the object actually

--- a/R/ggd.1.R
+++ b/R/ggd.1.R
@@ -329,7 +329,7 @@ f.t3.p <- list( function( x, m, s )
 #'                          \dfrac{\Phi^*_{i,2}(x)}{\sqrt{2}}. \hspace{3em} \ }}
 #'      }
 #'
-#'      Where \eqn{f_i} is the probability density function of
+#'      In above formulas, \eqn{f_i} is the probability density function of
 #'      the normal distribution \eqn{\mathcal{N}_i},
 #'      \eqn{\Phi_i} and \eqn{\Phi_{i,j}} are the cumulative distribution functions of
 #'      \eqn{\mathcal{N}_i} and \eqn{\mathcal{N}_{i,j}},

--- a/R/ggd.1.R
+++ b/R/ggd.1.R
@@ -60,7 +60,7 @@ f.t3.p <- list( function( x, m, s )
 #' @field   kind            A character string; the name of the kind of the distribution model.
 #'
 #'          \code{kind} shows the classification of each of the 6 distribution models
-#'          shown in 'Details', subdivided (except for the normal distribution)
+#'          shown in \sQuote{Details}, subdivided (except for the normal distribution)
 #'          into 3 categories based on whether the mean values or standard deviations
 #'          of the components are all equal or not.
 #'          Therefore, there are 16 (= 5 x 3 + 1) \code{kind}s in this package defined in
@@ -223,8 +223,8 @@ f.t3.p <- list( function( x, m, s )
 #'      The tops of \eqn{f_1} and \eqn{f_2} could be far apart from each other,
 #'      and moreover, the top of \eqn{\mathcal{G}[\mathcal{N}_1 \uparrow \mathcal{N}_2]}
 #'      could be nearby the top of \eqn{f_1}, instead of \eqn{f_2}.
-#'      That may be contrary to the intuitive image of the 'vertical gradational distribution',
-#'      but it is not prohibited.
+#'      That may be contrary to the intuitive image of
+#'      \sQuote{vertical gradational distribution}, but it is not prohibited.
 #'
 #'      About the \bold{3-component vertical gradational Gaussian distribution},
 #'      you can divide the tail-side distribution along x-axis into left (lower) side
@@ -450,7 +450,7 @@ GGD$methods(
 #' Adjust each row name of cmp
 #'
 #' Sets each row name of \code{cmp} field according to \code{mix.type} field.
-#' Normally, users of this class don't need to call this method directly.
+#' Normally, users of this class do not need to call this method directly.
 #' @name    adjust.cmp.rownames
 #' @aliases adjust.cmp.rownames
 #' @aliases \S4method{adjust.cmp.rownames}{GGD}
@@ -508,7 +508,7 @@ GGD$methods(
 #'
 #' Sets \code{kind.index} and \code{kind} fields according to
 #' \code{mix.type} and \code{cmp} fields.
-#' Normally, users of this class don't need to call this method directly.
+#' Normally, users of this class do not need to call this method directly.
 #' @name    adjust.kind.index
 #' @aliases adjust.kind.index
 #' @aliases \S4method{adjust.kind.index}{GGD}
@@ -679,7 +679,7 @@ GGD$methods(
 #'
 #'                      Each element must be a character string of a regular expression pattern
 #'                      matching to an element of \code{ggd:::kinds}
-#'                      (see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}})
+#'                      (see \code{kind} in \sQuote{Fields} at \code{\link[ggd]{GGD-class}})
 #'                      or an index number of \code{ggd:::kinds},
 #'                      or a \code{\link[ggd]{GGD}} object, or an \code{NA}.
 #'
@@ -690,7 +690,7 @@ GGD$methods(
 #'                      \code{ c(1L, 4L, 2L, 3L, 7L, 5L, 6L, 10L, 8L, 9L, 13L, 11L, 12L,
 #'                               16L, 14L, 15L)}.
 #'                      The order is designed for practical purposes so that
-#'                      the '\code{Mean-Differed Sigma-Differed}' model,
+#'                      the \code{"Mean-Differed Sigma-Differed"} model,
 #'                      which has more degrees of freedom than the others of the same type,
 #'                      can be matched first.
 #'
@@ -884,7 +884,7 @@ ggd.kind <- function( objs )
 #'          \code{integer(0)} is returned when \code{grad} is \code{"default"}.
 #'
 #'          Although the length of \code{grad} argument must be 1 (or 0 as the default),
-#'          but lengths of other arguments are not checked in this function consciously.
+#'          the lengths of other arguments are not checked in this function consciously.
 #'          So if \code{grad} is \code{"default"}, a vector of 2 or more length can be returned.
 #'          That means, the length of other arguments or the return value must be checked
 #'          by the caller of this function if necessary.
@@ -1025,7 +1025,7 @@ ggd.ncmp.for <- function( grad = c( "default", "normal", "h", "v", "v2", "v3", "
 #' Judge if all mean values are equal
 #'
 #' Checks if the mean values of all normal distributions of components are equal.
-#' The equality is determined by the '\code{==}' operator.
+#' The equality is determined by the \code{\link[base]{==}} operator.
 #' @name    is.eq.mean
 #' @aliases is.eq.mean
 #' @aliases \S4method{is.eq.mean}{GGD}
@@ -1058,7 +1058,7 @@ GGD$methods(
 #' Judge if all standard deviations are equal
 #'
 #' Checks if the standard deviations of all normal distributions of components are equal.
-#' The equality is determined by the '\code{==}' operator.
+#' The equality is determined by the \code{\link[base]{==}} operator.
 #' @name    is.eq.sd
 #' @aliases is.eq.sd
 #' @aliases is.eq.sigma

--- a/R/ggd.apply.R
+++ b/R/ggd.apply.R
@@ -23,7 +23,7 @@
 #'                  If \code{NULL}, nothing is applied.
 #' @param   f.sd    A function to apply to elements in \code{sd} column.
 #'                  If \code{NULL}, nothing is applied.
-#'                  See 'Details' for more information.
+#'                  See \sQuote{Details} for more information.
 #' @return  The processed \code{\link[ggd]{GGD}} object itself (invisible).
 #' @seealso \code{\link[ggd]{round.cmp}}
 #' @details
@@ -34,10 +34,10 @@
 #'          \item The \code{\link[ggd]{GGD}} object itself.
 #'      }
 #'      Therefore, the function for \code{f.mean} or \code{f.cmp} is hoped to be
-#'      declared with 2 arguments like as '\code{function(mean, obj)}',
+#'      declared with 2 arguments like as \code{function(mean, obj)},
 #'      however, if the function do not need the 2nd argument,
 #'      you can declare with 1 arguments
-#'      like as '\code{function(mean)}' or '\code{function(sd)}'.
+#'      like as \code{function(mean)} or \code{function(sd)}.
 #'      For the values of the functions, each function must return a numeric vector
 #'      with the same length of the 1st argument as new values of each column.
 #'

--- a/R/ggd.file.R
+++ b/R/ggd.file.R
@@ -153,7 +153,7 @@ GGD$methods(
 #'      Mean values and standard deviations are recorded to a maximum length of
 #'      the 22nd decimal place.
 #'      The accuracy is sufficient to reconstruct the original object almost completely
-#'      (at least the value of each field can be \code{TRUE} with '\code{==}')
+#'      (at least the value of each field can be \code{TRUE} with \code{\link[base]{==}})
 #'      in most cases, and in most systems.
 #' }
 #'

--- a/R/ggd.mean.sd.R
+++ b/R/ggd.mean.sd.R
@@ -333,12 +333,13 @@ calc.v <- function( mix.type, means, sds,
 #' [Non-exported] Sub-function for variance calculation where mix.type = 2, 3
 #'
 #' A sub-function of \code{\link[ggd]{calc.v}} where \code{mix.type} is \code{2} or \code{3}.
-#' The meaning of this function is depend on \code{mix.type} (see 'Details').
+#' The meaning of this function is depend on \code{mix.type} (see \sQuote{Details}).
 #' @param   mix.type    The value of \code{mix.type}. It allows \code{2} or \code{3}.
 #' @param   mean        The mean of the distribution model.
 #' @param   mean.i      The mean value of the i-th normal distribution of the component.
 #' @param   sd.i        The standard deviation of the i-th normal distribution of the component.
-#' @param   x           The upper limit of the integral interval (see formulas in 'Details').
+#' @param   x           The upper limit of the integral interval
+#'                      (see formulas in \sQuote{Details}).
 #' @param   p.sum       The sum of the probabilities of two normal distributions of
 #'                      the components at \code{x = q}; the lower or upper limit of the domain
 #'                      of the distribution.
@@ -387,7 +388,7 @@ calc.v <- function( mix.type, means, sds,
 #'  \code{\link[base]{sqrt}(pi)} are used, it is expected that there will be calculation errors
 #'  due to their implementation, in addition to digit losses during arithmetic operations.
 #'
-#' @return  Calculated value of the expression shown in 'Details'.
+#' @return  Calculated value of the expression shown in \sQuote{Details}.
 #' @importFrom  stats   dnorm pnorm
 ################################################################################################
 calc.v.sub <- function( mix.type, mean, mean.i, sd.i, x, p.sum = 0, i = 0 )
@@ -537,7 +538,7 @@ calc.v.t4.via.integrate <- function( means, sds, mean = calc.mean( 4, means, sds
 #' Calculates the median, the mean, and the standard deviation of the distribution model and
 #' then sets those values into the fields.
 #' Before calling this method, you must set \code{cmp} and \code{mix.type} fields.
-#' Normally, users of this class don't need to call this method directly.
+#' Normally, users of this class do not need to call this method directly.
 #' @name    adjust.median.mean.sd
 #' @aliases adjust.median.mean.sd
 #' @aliases \S4method{adjust.median.mean.sd}{GGD}

--- a/R/ggd.nls.freq.R
+++ b/R/ggd.nls.freq.R
@@ -251,7 +251,7 @@
 #'                      and \code{grad} argument is \code{"default"},
 #'                      the current value of \code{mix.type} field will be retained,
 #'                      and number of components will also.
-#'                      However, if the object has been cleared when this method is called,
+#'                      But note if the object has been cleared when this method is called,
 #'                      \code{mix.type} field will be \code{2}, the start value.
 #'
 #' @return  A list containing components (invisible for \code{GGD} method)

--- a/R/ggd.nls.freq.R
+++ b/R/ggd.nls.freq.R
@@ -788,7 +788,7 @@ nls.freq.level.100 <- function( data, total, kind, mix.type,
 #' Approximating a frequency distribution with all of supported models
 #'
 #' Approximates the given frequency distribution with all of distribution models
-#' available in this package (the number of models is 16), and compare their accuracies.
+#' available in this package (the number of models is 16), and compares their accuracies.
 #' The accuracy is checked by the correlation coefficients with the frequency distribution
 #' computed by \code{\link[stats]{cor}}.
 #'

--- a/R/ggd.nls.freq.R
+++ b/R/ggd.nls.freq.R
@@ -792,27 +792,9 @@ nls.freq.level.100 <- function( data, total, kind, mix.type,
 #' The accuracy is checked by the correlation coefficients with the frequency distribution
 #' computed by \code{\link[stats]{cor}}.
 #'
-#' The output lists are ordered by \code{ggd:::kinds} as:
-#' \enumerate{
-#'      \item   Normal Distribution
-#'      \item   Mean of Mean-Differed Sigma-Equaled 2 Normal Distributions
-#'      \item   Mean of Mean-Equaled Sigma-Differed 2 Normal Distributions
-#'      \item   Mean of Mean-Differed Sigma-Differed 2 Normal Distributions
-#'      \item   Mean-Differed Sigma-Equaled Horizontal Gradational Distribution
-#'      \item   Mean-Equaled Sigma-Differed Horizontal Gradational Distribution
-#'      \item   Mean-Differed Sigma-Differed Horizontal Gradational Distribution
-#'      \item   2-Mean-Differed Sigma-Equaled Vertical Gradational Distribution
-#'      \item   2-Mean-Equaled Sigma-Differed Vertical Gradational Distribution
-#'      \item   2-Mean-Differed Sigma-Differed Vertical Gradational Distribution
-#'      \item   3-Mean-Differed Sigma-Equaled Vertical Gradational Distribution
-#'      \item   3-Mean-Equaled Sigma-Differed Vertical Gradational Distribution
-#'      \item   3-Mean-Differed Sigma-Differed Vertical Gradational Distribution
-#'      \item   Mean-Differed Sigma-Equaled Horizontal-Vertical Gradational Distribution
-#'      \item   Mean-Equaled Sigma-Differed Horizontal-Vertical Gradational Distribution
-#'      \item   Mean-Differed Sigma-Differed Horizontal-Vertical Gradational Distribution
-#' }
-#' Each index number of above list is
-#' also set into \code{kind.index} field of each \code{\link[ggd]{GGD}} object.
+#' The output lists are ordered by index number of \code{ggd:::kinds},
+#' which will be set into \code{kind.index} field of each object
+#' (see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}}).
 #'
 #' This function generates 16 \code{\link[ggd]{GGD}} objects and
 #' calls \code{\link[ggd]{nls.freq}} method 16 times.

--- a/R/ggd.nls.freq.R
+++ b/R/ggd.nls.freq.R
@@ -17,7 +17,7 @@
 #' the given frequency distribution.
 #' Then \code{ggd.nls.freq} function generates a \code{\link[ggd]{GGD}} object,
 #' and \code{nls.freq} method sets the fields according to the result.
-#' 'Locally' means that if the start value is modified, more closely approximating model
+#' \sQuote{Locally} means that if the start value is modified, more closely approximating model
 #' may be constructed.
 #' The outliers of the frequency distribution will not be excluded in this function.
 #' If necessary, outliers should be excluded by preprocessing.
@@ -224,7 +224,7 @@
 #'                      See \code{\link[stats]{cor}} for more information.
 #'
 #' @param   ...         Each argument for \code{\link[stats]{nls}} can be indicated.
-#'                      See 'Arguments' of \code{\link[stats]{nls}} for more information.
+#'                      See \sQuote{Arguments} of \code{\link[stats]{nls}} for more information.
 #'
 #' @param   this.kind   A character string or a numeric value or a \code{\link[ggd]{GGD}} object
 #'                      which indicates the kind of distribution model to be constructed.
@@ -264,7 +264,7 @@
 #'          \item{nls.out}{
 #'                  The list of the output of \code{\link[stats]{nls}}.
 #'                  If \code{\link[stats]{nls}} has not been used, \code{NULL} will be set.
-#'                  See 'Value' of \code{\link[stats]{nls}} for more information.}
+#'                  See \sQuote{Value} of \code{\link[stats]{nls}} for more information.}
 #'          \item{start.level}{
 #'                  The initial guessing level which is used actually to obtain \code{obj}.
 #'                  If \code{start.level = 100} is indicated,
@@ -306,7 +306,7 @@
 #'          \code{\link[ggd]{ggd.nls.freq.all}}, \code{\link[ggd]{ggd.start.template}}
 #'
 #' @details
-#'  \subsection{Why the standard deviations for 'start' are square-rooted?}{
+#'  \subsection{Why the standard deviations for start are square-rooted?}{
 #'      You know a standard deviation must be a positive value.
 #'      But if you use standard deviations directly in the formula for \code{\link[stats]{nls}},
 #'      they sometimes drop into negative values while the Gauss-Newton algorithm is running
@@ -713,7 +713,7 @@ GGD$methods(
 #'                      See \code{\link[stats]{nls.control}} for more information.
 #' @param   cor.method  The \code{method} argument for \code{\link[stats]{cor}}.
 #' @param   ...         Each argument for \code{\link[stats]{nls}} can be indicated.
-#'                      See 'Arguments' of \code{\link[stats]{nls}} for more information.
+#'                      See \sQuote{Arguments} of \code{\link[stats]{nls}} for more information.
 #' @return  A list conforming the return value of \code{\link[ggd]{nls.freq}}.
 #' @seealso \code{\link[ggd]{nls.freq}}
 ################################################################################################
@@ -794,25 +794,25 @@ nls.freq.level.100 <- function( data, total, kind, mix.type,
 #'
 #' The output lists are ordered by index number of \code{ggd:::kinds},
 #' which will be set into \code{kind.index} field of each object
-#' (see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}}).
+#' (see \code{kind} in \sQuote{Fields} at \code{\link[ggd]{GGD-class}}).
 #'
 #' This function generates 16 \code{\link[ggd]{GGD}} objects and
 #' calls \code{\link[ggd]{nls.freq}} method 16 times.
 #' By default, \code{\link[ggd]{nls.freq}} is called with \code{warnOnly = TRUE},
 #' so \code{\link[ggd]{nls.freq}} does not generate errors, but generates warnings often.
 #' When a warning occur, this function generates another warning like
-#' '\code{Warning for kind = xx :}' to inform which \code{kind.index} gets a poor result
+#' \code{"Warning for kind = xx :"} to inform which \code{kind.index} gets a poor result
 #' (poor, but may be accurate enough).
 #' So when one warning has occurred, two warnings will occur eventually.
 #'
 #' If you indicate \code{warnOnly = FALSE} in \code{control} argument
 #' and overwrite \code{warnOnly} option, \code{\link[ggd]{nls.freq}} can generate errors.
 #' If an error occurs in one of \code{\link[ggd]{nls.freq}} processes,
-#' this function throws messages like '\code{Error for kind = xx :}' and '\code{Error in ...}'
+#' this function throws messages like \code{"Error for kind = xx :"} and \code{"Error in ..."}
 #' instead of throwing an error and skips the process,
 #' then tries other \code{\link[ggd]{nls.freq}} processes.
 #' For the result of error-occurred \code{kind.index}, a cleared \code{\link[ggd]{GGD}} object
-#' will be got as the element of \code{obj} (see 'Value').
+#' will be got as the element of \code{obj} (see \sQuote{Value}).
 #'
 #' @export
 #' @param   data    A data frame which represents the frequency distribution.
@@ -854,7 +854,7 @@ nls.freq.level.100 <- function( data, total, kind, mix.type,
 #'                  In addition, \code{\link[ggd]{ggd.kind}} and
 #'                  \code{\link[ggd]{ggd.kind.index}} functions may help you whether
 #'                  each index number of \code{start} represents what kind of distribution.
-#'                  See 'Examples' for usages of these tools.
+#'                  See \sQuote{Examples} for usages of these tools.
 #'
 #' @param   control The \code{control} argument for \code{\link[stats]{nls}}.
 #'                  See \code{\link[stats]{nls.control}} for more information.
@@ -879,7 +879,7 @@ nls.freq.level.100 <- function( data, total, kind, mix.type,
 #'                      See \code{\link[stats]{cor}} for more information.
 #'
 #' @param   ...     Each argument for \code{\link[stats]{nls}} can be indicated.
-#'                  See 'Arguments' of \code{\link[stats]{nls}} for more information.
+#'                  See \sQuote{Arguments} of \code{\link[stats]{nls}} for more information.
 #'
 #' @return  A list containing components
 #'          \item{best}{
@@ -910,7 +910,7 @@ nls.freq.level.100 <- function( data, total, kind, mix.type,
 #'                  Normally, each element is a list of the output of
 #'                  \code{\link[ggd]{nls.freq}}.
 #'                  But if an error has occurred, the element will be an error condition.
-#'                  See 'Value' of \code{\link[ggd]{nls.freq}} for more information.}
+#'                  See \sQuote{Value} of \code{\link[ggd]{nls.freq}} for more information.}
 #'
 #' @importFrom  methods     new
 #' @seealso \code{\link[ggd]{nls.freq}}, \code{\link[stats]{cor}},

--- a/R/ggd.nls.freq.R
+++ b/R/ggd.nls.freq.R
@@ -94,7 +94,7 @@
 #'                          \item 1: Mean of 2 normal distributions.
 #'                          \item 2: Horizontal gradation of 2 normal distributions.
 #'                          \item 3: Vertical gradation of 2 (or 3) normal distributions.
-#'                          \item 4: Horizontal-Vertical gradation
+#'                          \item 4: Horizontal-vertical gradation
 #'                                   with 4 (2x2) normal distributions.
 #'                      }
 #'

--- a/R/ggd.set.cmp.R
+++ b/R/ggd.set.cmp.R
@@ -57,16 +57,13 @@
 #'
 #'                      The type of the distribution model and the number of rows in \code{cmp}
 #'                      follow \code{mix.type} as:
-#'                      \itemize{
-#'                          \item \code{0} : Normal distribution. \code{cmp} has only 1 row.
-#'                          \item \code{1} : Mean of 2 normal distributions.
-#'                                           \code{cmp} has 2 rows.
-#'                          \item \code{2} : Horizontal gradational distribution.
-#'                                           \code{cmp} has 2 rows.
-#'                          \item \code{3} : Vertical gradational distribution.
-#'                                           \code{cmp} has 2 or 3 rows.
-#'                          \item \code{4} : Horizontal-vertical gradational distribution.
-#'                                           \code{cmp} has 4 rows.
+#'                      \tabular{clc}{
+#'                          \code{mix.type} \tab Distribution model     \tab Number of rows \cr
+#'                          \code{0} \tab Normal distribution                   \tab 1 \cr
+#'                          \code{1} \tab Mean of 2 normal distributions        \tab 2 \cr
+#'                          \code{2} \tab Horizontal gradational distribution   \tab 2 \cr
+#'                          \code{3} \tab Vertical gradational distribution     \tab 2 or 3 \cr
+#'                          \code{4} \tab Horizontal-vertical gradational distribution  \tab 4
 #'                      }
 #'
 #'                      If the number of rows in \code{cmp} argument is different from

--- a/R/ggd.set.cmp.R
+++ b/R/ggd.set.cmp.R
@@ -84,7 +84,8 @@
 #'                      Numberless \code{"v"} is an alias for \code{"v2"}.
 #'
 #'                      \code{"normal"} is for a normal distribution,
-#'                      then also, \code{'grad = "no"'} can be read as 'no gradation'.
+#'                      then also, \sQuote{\code{grad = "no"}} can be read as
+#'                      \sQuote{no gradation}.
 #'
 #'                      \code{"default"} is, if \code{kind} or \code{mix.type} argument
 #'                      is given, follows it, otherwise it depends on the number of columns
@@ -108,7 +109,7 @@
 #' @importFrom  methods     new
 #'
 #' @details
-#'  \subsection{About 'kind' and 'mix.type'}{
+#'  \subsection{About kind and mix.type}{
 #'      In this function,
 #'      unlike \code{\link[ggd]{trace.q}} and \code{\link[ggd]{nls.freq}} methods,
 #'      \code{[this.]kind} argument is only used to determine \code{mix.type} value,

--- a/R/ggd.tex.R
+++ b/R/ggd.tex.R
@@ -226,15 +226,15 @@ tex.end.frac.env = c( "array"       = "\\\\end{array} ",
 #'          frac.env = c("array", "aligned", "gathered", "default"))
 #' @param   con         A \code{\link[base]{connection}} object or a character string
 #'                      to indicate the output destination.
-#'                      See 'Details' at \code{\link[base]{writeLines}}
+#'                      See \sQuote{Details} at \code{\link[base]{writeLines}}
 #'                      for more information.
 #' @param   sep         A character string to be written to the connection after each line
-#'                      of text. See 'Details' at \code{\link[base]{writeLines}}
+#'                      of text. See \sQuote{Details} at \code{\link[base]{writeLines}}
 #'                      for more information.
-#' @param   comma       A logical. If \code{TRUE}, this method writes a ',' (comma)
-#'                      as a separator between each expression and a '.' (period)
+#' @param   comma       A logical. If \code{TRUE}, this method writes a \sQuote{,} (comma)
+#'                      as a separator between each expression and a \sQuote{.} (period)
 #'                      at the end of the output.
-#'                      If \code{FALSE}, those ',' and '.' will not be written.
+#'                      If \code{FALSE}, those \sQuote{,} and \sQuote{.} will not be written.
 #' @param   format.num  A function to format each numeric value of mean values and
 #'                      standard deviations.
 #'                      It should be a function with one argument for the value
@@ -268,17 +268,17 @@ tex.end.frac.env = c( "array"       = "\\\\end{array} ",
 #'  \subsection{Equaled mean values or standard deviations}{
 #'      For clarity, when all mean values or standard deviations of components are equal
 #'      (i.e., when \code{\link[ggd]{is.eq.mean}} or \code{\link[ggd]{is.eq.sd}} method
-#'      returns \code{TRUE}), they are displayed with '\eqn{=}' to the 1st parameter,
-#'      like as '\eqn{\sigma_2 = \sigma_1}'.
+#'      returns \code{TRUE}), they are displayed with \sQuote{\eqn{=}} to the 1st parameter,
+#'      like as \sQuote{\eqn{\sigma_2 = \sigma_1}}.
 #'
 #'      If only the values of some parameters are equal (e.g., only \eqn{\sigma_2} and
 #'      \eqn{\sigma_3} are equal and \eqn{\sigma_1} is different),
-#'      each value is displayed as '\eqn{\sigma_2 = x, \sigma_3 = x}'
-#'      instead of '\eqn{\sigma_3 = \sigma_2}' to avoid misreading.
+#'      each value is displayed as \sQuote{\eqn{\sigma_2 = x, \sigma_3 = x}}
+#'      instead of \sQuote{\eqn{\sigma_3 = \sigma_2}} to avoid misreading.
 #'
 #'      Note that if the difference between the values of parameters is smaller than
-#'      displayable number of decimal places, '\eqn{\sigma_2 = \sigma_1}' will not be displayed,
-#'      but the same number will be displayed for each.
+#'      displayable number of decimal places, \sQuote{\eqn{\sigma_2 = \sigma_1}}
+#'      will not be displayed, but the same number will be displayed for each.
 #'  }
 #' @examples
 #'  a <- GGD$new()

--- a/R/ggd.trace.q.R
+++ b/R/ggd.trace.q.R
@@ -107,7 +107,7 @@
 #'                      to be equal.
 #'                      This condition reduces the degrees of freedom,
 #'                      so allowed number of quantiles will be restricted.
-#'                      See 'Details' for more information.
+#'                      See \sQuote{Details} for more information.
 #'
 #'                      If \code{FALSE}, the mean values are not bound,
 #'                      and mean-equaled components will be rarely constructed.
@@ -127,7 +127,7 @@
 #'                      the components to be equal.
 #'                      This condition reduces the degrees of freedom,
 #'                      so allowed number of quantiles will be restricted.
-#'                      See 'Details' for more information.
+#'                      See \sQuote{Details} for more information.
 #'
 #'                      If \code{FALSE} or \code{logical(0)},
 #'                      the standard deviations are not bound,

--- a/R/ggd.trace.q.R
+++ b/R/ggd.trace.q.R
@@ -75,7 +75,7 @@
 #'                          \item \code{2} : Horizontal gradation of 2 normal distributions.
 #'                          \item \code{3} : Vertical gradation of 2 or 3 normal distributions.
 #'                                           The 2-component model has priority.
-#'                          \item \code{4} : Horizontal-Vertical gradation
+#'                          \item \code{4} : Horizontal-vertical gradation
 #'                                           with 4 (2x2) normal distributions.
 #'                      }
 #'                      If \code{NULL}

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,14 @@
 ── R CMD check results ───────────────────────────────── ggd 1.0.4 ────
-Duration: 16m 55s
+Duration: 16m 50.3s
 
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
 ── ggd 1.0.4: NOTE
 
-  Build ID:   ggd_1.0.4.tar.gz-9d9310b3598542018a4db090335d5549
+  Build ID:   ggd_1.0.4.tar.gz-54ff92bd21b6422e8d766b89962883b3
   Platform:   Windows Server 2022, R-devel, 64 bit
-  Submitted:  3h 40m 9.3s ago
-  Build time: 31m 58.9s
+  Submitted:  39m 6.4s ago
+  Build time: 30m 10.7s
 
 ❯ checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Kimitsuna Ura <kimitsuna@i.softbank.jp>'
@@ -30,38 +30,38 @@ Duration: 16m 55s
 
 ── ggd 1.0.4: NOTE
 
-  Build ID:   ggd_1.0.4.tar.gz-4958b55146274ef6b1ed14ebb0b50177
+  Build ID:   ggd_1.0.4.tar.gz-15cae83e843f44488bd5dd6041ffbf24
   Platform:   Ubuntu Linux 20.04.1 LTS, R-release, GCC
-  Submitted:  3h 40m 9.4s ago
-  Build time: 40m 39.4s
+  Submitted:  39m 6.5s ago
+  Build time: 37m 43.8s
 
-❯ checking CRAN incoming feasibility ... [6s/21s] NOTE
+❯ checking CRAN incoming feasibility ... [6s/18s] NOTE
   Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
   
   New submission
 
-❯ checking examples ... [13s/36s] NOTE
+❯ checking examples ... [13s/31s] NOTE
   Examples with CPU (user + system) or elapsed time > 5s
                     user system elapsed
-  ggd.nls.freq.all 3.158  0.003   8.742
+  ggd.nls.freq.all 3.054  0.008   7.087
 
 0 errors ✔ | 0 warnings ✔ | 2 notes ✖
 
 ── ggd 1.0.4: NOTE
 
-  Build ID:   ggd_1.0.4.tar.gz-8ad5160da96b49dd9fe73a31e00b3517
+  Build ID:   ggd_1.0.4.tar.gz-dddd19fd21974d48b49aa7dfa81fd566
   Platform:   Fedora Linux, R-devel, clang, gfortran
-  Submitted:  3h 40m 9.4s ago
-  Build time: 40m 16.9s
+  Submitted:  39m 6.5s ago
+  Build time: 37m 28.8s
 
-❯ checking CRAN incoming feasibility ... [6s/25s] NOTE
+❯ checking CRAN incoming feasibility ... [6s/20s] NOTE
   Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
   
   New submission
 
-❯ checking examples ... [14s/38s] NOTE
+❯ checking examples ... [14s/33s] NOTE
   Examples with CPU (user + system) or elapsed time > 5s
                     user system elapsed
-  ggd.nls.freq.all 3.379      0   8.647
+  ggd.nls.freq.all 3.206  0.012   7.797
 
-0 errors ✔ | 0 warnings ✔ | 2 notes ✖]
+0 errors ✔ | 0 warnings ✔ | 2 notes ✖

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,14 @@
-── R CMD check results ────────────────────────────── ggd 1.0.3.2 ────
-Duration: 16m 9.8s
+── R CMD check results ───────────────────────────────── ggd 1.0.4 ────
+Duration: 16m 55s
 
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
-── ggd 1.0.3.2: NOTE
+── ggd 1.0.4: NOTE
 
-  Build ID:   ggd_1.0.3.2.tar.gz-fa3810ac78e44f2891f92e62f44e4afa
+  Build ID:   ggd_1.0.4.tar.gz-9d9310b3598542018a4db090335d5549
   Platform:   Windows Server 2022, R-devel, 64 bit
-  Submitted:  39m 17.8s ago
-  Build time: 30m 52.7s
+  Submitted:  3h 40m 9.3s ago
+  Build time: 31m 58.9s
 
 ❯ checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Kimitsuna Ura <kimitsuna@i.softbank.jp>'
@@ -28,16 +28,40 @@ Duration: 16m 9.8s
 
 0 errors ✔ | 0 warnings ✔ | 4 notes ✖
 
-── ggd 1.0.3.2: IN-PROGRESS
+── ggd 1.0.4: NOTE
 
-  Build ID:   ggd_1.0.3.2.tar.gz-58b879039a31484b8350c34d3d9bd8b5
+  Build ID:   ggd_1.0.4.tar.gz-4958b55146274ef6b1ed14ebb0b50177
   Platform:   Ubuntu Linux 20.04.1 LTS, R-release, GCC
-  Submitted:  39m 17.9s ago
+  Submitted:  3h 40m 9.4s ago
+  Build time: 40m 39.4s
 
-
-── ggd 1.0.3.2: IN-PROGRESS
-
-  Build ID:   ggd_1.0.3.2.tar.gz-b2fab5d522ad47c2a544049a758798e7
-  Platform:   Fedora Linux, R-devel, clang, gfortran
-  Submitted:  39m 17.9s ago
+❯ checking CRAN incoming feasibility ... [6s/21s] NOTE
+  Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
   
+  New submission
+
+❯ checking examples ... [13s/36s] NOTE
+  Examples with CPU (user + system) or elapsed time > 5s
+                    user system elapsed
+  ggd.nls.freq.all 3.158  0.003   8.742
+
+0 errors ✔ | 0 warnings ✔ | 2 notes ✖
+
+── ggd 1.0.4: NOTE
+
+  Build ID:   ggd_1.0.4.tar.gz-8ad5160da96b49dd9fe73a31e00b3517
+  Platform:   Fedora Linux, R-devel, clang, gfortran
+  Submitted:  3h 40m 9.4s ago
+  Build time: 40m 16.9s
+
+❯ checking CRAN incoming feasibility ... [6s/25s] NOTE
+  Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
+  
+  New submission
+
+❯ checking examples ... [14s/38s] NOTE
+  Examples with CPU (user + system) or elapsed time > 5s
+                    user system elapsed
+  ggd.nls.freq.all 3.379      0   8.647
+
+0 errors ✔ | 0 warnings ✔ | 2 notes ✖]

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,14 @@
-── R CMD check results ──────────────────────────────────── ggd 1.0.3.1 ────
-Duration: 16m 45.4s
+── R CMD check results ────────────────────────────── ggd 1.0.3.1 ────
+Duration: 16m 33.8s
 
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
 ── ggd 1.0.3.1: NOTE
 
-  Build ID:   ggd_1.0.3.1.tar.gz-99d0690e152d4e7cac299f044a2ed8ff
+  Build ID:   ggd_1.0.3.1.tar.gz-23bd9cb3d461478cbb2b1e04d0489eed
   Platform:   Windows Server 2022, R-devel, 64 bit
-  Submitted:  47m 16.1s ago
-  Build time: 30m 38.5s
+  Submitted:  2h 6m 4.7s ago
+  Build time: 30m 49.5s
 
 ❯ checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Kimitsuna Ura <kimitsuna@i.softbank.jp>'
@@ -30,38 +30,38 @@ Duration: 16m 45.4s
 
 ── ggd 1.0.3.1: NOTE
 
-  Build ID:   ggd_1.0.3.1.tar.gz-18b001e039e14923b2dae0deb0a5a7c5
+  Build ID:   ggd_1.0.3.1.tar.gz-1382bedfb62f460ba7d2bdc6ed9a9c91
   Platform:   Ubuntu Linux 20.04.1 LTS, R-release, GCC
-  Submitted:  47m 16.2s ago
-  Build time: 38m 17.6s
+  Submitted:  2h 6m 4.9s ago
+  Build time: 39m 31.8s
 
-❯ checking CRAN incoming feasibility ... [6s/19s] NOTE
+❯ checking CRAN incoming feasibility ... [6s/18s] NOTE
   Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
   
   New submission
 
-❯ checking examples ... [13s/31s] NOTE
+❯ checking examples ... [14s/34s] NOTE
   Examples with CPU (user + system) or elapsed time > 5s
                     user system elapsed
-  ggd.nls.freq.all 3.073      0   6.968
+  ggd.nls.freq.all 3.249  0.007   8.096
 
 0 errors ✔ | 0 warnings ✔ | 2 notes ✖
 
 ── ggd 1.0.3.1: NOTE
 
-  Build ID:   ggd_1.0.3.1.tar.gz-d9ac4f179cad4ff29ec454f19e45df79
+  Build ID:   ggd_1.0.3.1.tar.gz-1e68c8f785374d76bf76c6dbd822d9d0
   Platform:   Fedora Linux, R-devel, clang, gfortran
-  Submitted:  47m 16.2s ago
-  Build time: 37m 50s
+  Submitted:  2h 6m 4.9s ago
+  Build time: 39m 24s
 
-❯ checking CRAN incoming feasibility ... [6s/22s] NOTE
+❯ checking CRAN incoming feasibility ... [7s/22s] NOTE
   Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
   
   New submission
 
-❯ checking examples ... [14s/31s] NOTE
+❯ checking examples ... [14s/36s] NOTE
   Examples with CPU (user + system) or elapsed time > 5s
                     user system elapsed
-  ggd.nls.freq.all 3.118      0   7.012
+  ggd.nls.freq.all 3.312  0.004   8.307
 
 0 errors ✔ | 0 warnings ✔ | 2 notes ✖

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,14 +1,14 @@
-── R CMD check results ────────────────────────────── ggd 1.0.3.1 ────
-Duration: 16m 33.8s
+── R CMD check results ────────────────────────────── ggd 1.0.3.2 ────
+Duration: 16m 9.8s
 
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
-── ggd 1.0.3.1: NOTE
+── ggd 1.0.3.2: NOTE
 
-  Build ID:   ggd_1.0.3.1.tar.gz-23bd9cb3d461478cbb2b1e04d0489eed
+  Build ID:   ggd_1.0.3.2.tar.gz-fa3810ac78e44f2891f92e62f44e4afa
   Platform:   Windows Server 2022, R-devel, 64 bit
-  Submitted:  2h 6m 4.7s ago
-  Build time: 30m 49.5s
+  Submitted:  39m 17.8s ago
+  Build time: 30m 52.7s
 
 ❯ checking CRAN incoming feasibility ... NOTE
   Maintainer: 'Kimitsuna Ura <kimitsuna@i.softbank.jp>'
@@ -28,40 +28,16 @@ Duration: 16m 33.8s
 
 0 errors ✔ | 0 warnings ✔ | 4 notes ✖
 
-── ggd 1.0.3.1: NOTE
+── ggd 1.0.3.2: IN-PROGRESS
 
-  Build ID:   ggd_1.0.3.1.tar.gz-1382bedfb62f460ba7d2bdc6ed9a9c91
+  Build ID:   ggd_1.0.3.2.tar.gz-58b879039a31484b8350c34d3d9bd8b5
   Platform:   Ubuntu Linux 20.04.1 LTS, R-release, GCC
-  Submitted:  2h 6m 4.9s ago
-  Build time: 39m 31.8s
+  Submitted:  39m 17.9s ago
 
-❯ checking CRAN incoming feasibility ... [6s/18s] NOTE
-  Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
-  
-  New submission
 
-❯ checking examples ... [14s/34s] NOTE
-  Examples with CPU (user + system) or elapsed time > 5s
-                    user system elapsed
-  ggd.nls.freq.all 3.249  0.007   8.096
+── ggd 1.0.3.2: IN-PROGRESS
 
-0 errors ✔ | 0 warnings ✔ | 2 notes ✖
-
-── ggd 1.0.3.1: NOTE
-
-  Build ID:   ggd_1.0.3.1.tar.gz-1e68c8f785374d76bf76c6dbd822d9d0
+  Build ID:   ggd_1.0.3.2.tar.gz-b2fab5d522ad47c2a544049a758798e7
   Platform:   Fedora Linux, R-devel, clang, gfortran
-  Submitted:  2h 6m 4.9s ago
-  Build time: 39m 24s
-
-❯ checking CRAN incoming feasibility ... [7s/22s] NOTE
-  Maintainer: ‘Kimitsuna Ura <kimitsuna@i.softbank.jp>’
+  Submitted:  39m 17.9s ago
   
-  New submission
-
-❯ checking examples ... [14s/36s] NOTE
-  Examples with CPU (user + system) or elapsed time > 5s
-                    user system elapsed
-  ggd.nls.freq.all 3.312  0.004   8.307
-
-0 errors ✔ | 0 warnings ✔ | 2 notes ✖

--- a/man/GGD-class.Rd
+++ b/man/GGD-class.Rd
@@ -189,7 +189,7 @@ The class provides the Gradational Gaussian Distribution.
                          \dfrac{\Phi^*_{i,2}(x)}{\sqrt{2}}. \hspace{3em} \ }}
      }
 
-     Where \eqn{f_i} is the probability density function of
+     In above formulas, \eqn{f_i} is the probability density function of
      the normal distribution \eqn{\mathcal{N}_i},
      \eqn{\Phi_i} and \eqn{\Phi_{i,j}} are the cumulative distribution functions of
      \eqn{\mathcal{N}_i} and \eqn{\mathcal{N}_{i,j}},

--- a/man/GGD-class.Rd
+++ b/man/GGD-class.Rd
@@ -83,8 +83,8 @@ The class provides the Gradational Gaussian Distribution.
      The tops of \eqn{f_1} and \eqn{f_2} could be far apart from each other,
      and moreover, the top of \eqn{\mathcal{G}[\mathcal{N}_1 \uparrow \mathcal{N}_2]}
      could be nearby the top of \eqn{f_1}, instead of \eqn{f_2}.
-     That may be contrary to the intuitive image of the 'vertical gradational distribution',
-     but it is not prohibited.
+     That may be contrary to the intuitive image of
+     \sQuote{vertical gradational distribution}, but it is not prohibited.
 
      About the \bold{3-component vertical gradational Gaussian distribution},
      you can divide the tail-side distribution along x-axis into left (lower) side
@@ -216,7 +216,7 @@ That is, the index number for the value of \code{kind} field.}
 \item{\code{kind}}{A character string; the name of the kind of the distribution model.
 
          \code{kind} shows the classification of each of the 6 distribution models
-         shown in 'Details', subdivided (except for the normal distribution)
+         shown in \sQuote{Details}, subdivided (except for the normal distribution)
          into 3 categories based on whether the mean values or standard deviations
          of the components are all equal or not.
          Therefore, there are 16 (= 5 x 3 + 1) \code{kind}s in this package defined in

--- a/man/GGD-class.Rd
+++ b/man/GGD-class.Rd
@@ -210,43 +210,80 @@ The class provides the Gradational Gaussian Distribution.
 \section{Fields}{
 
 \describe{
-\item{\code{kind.index}}{An integer; the index number of the kind of the distribution model.}
+\item{\code{kind.index}}{An integer; the number indicating the kind of distribution model.
+That is, the index number for the value of \code{kind} field.}
 
-\item{\code{kind}}{A string; the name of the kind of the distribution model.}
+\item{\code{kind}}{A character string; the name of the kind of the distribution model.
+
+         \code{kind} shows the classification of each of the 6 distribution models
+         shown in 'Details', subdivided (except for the normal distribution)
+         into 3 categories based on whether the mean values or standard deviations
+         of the components are all equal or not.
+         Therefore, there are 16 (= 5 x 3 + 1) \code{kind}s in this package defined in
+         \code{ggd:::kinds} as follows.
+
+         \tabular{clc}{
+             Index \tab Distribution model (\code{kind}) \cr
+             \code{1}  \tab Normal distribution \cr
+             \code{2}  \tab
+                 Mean of Mean-Differed Sigma-Equaled 2 Normal Distributions \cr
+             \code{3}  \tab Mean of Mean-Equaled Sigma-Differed " \cr
+             \code{4}  \tab Mean of Mean-Differed Sigma-Differed " \cr
+             \code{5}  \tab
+                 Mean-Differed Sigma-Equaled Horizontal Gradational Distribution \cr
+             \code{6}  \tab Mean-Equaled Sigma-Differed " \cr
+             \code{7}  \tab Mean-Differed Sigma-Differed " \cr
+             \code{8}  \tab
+                 2-Mean-Differed Sigma-Equaled Vertical Gradational Distribution \cr
+             \code{9}  \tab 2-Mean-Equaled Sigma-Differed " \cr
+             \code{10} \tab 2-Mean-Differed Sigma-Differed " \cr
+             \code{11} \tab 3-Mean-Differed Sigma-Equaled " \cr
+             \code{12} \tab 3-Mean-Equaled Sigma-Differed " \cr
+             \code{13} \tab 3-Mean-Differed Sigma-Differed " \cr
+             \code{14} \tab
+                 Mean-Differed Sigma-Equaled Horizontal-Vertical Gradational Distribution \cr
+             \code{15} \tab Mean-Equaled Sigma-Differed " \cr
+             \code{16} \tab Mean-Differed Sigma-Differed " \cr
+         }
+
+         \code{kind.index} and \code{kind} fields represent how the object actually
+         behaves as a distribution model. These fields are closely related to the number
+         of components (normal distributions) of the object and how they are mixed,
+         but are not entirely dependent on them.
+         For example, if a object with \code{mix.type = 1} (mean of 2 normal distributions)
+         has two same normal distributions as the components,
+         the object will actually behave as a normal distribution.
+         In this case, \code{kind.index} and \code{kind} fields indicate
+         \code{"Normal Distribution"} rather than \code{"Mean of 2 Normal Distributions"}.}
 
 \item{\code{mix.type}}{An integer which represents how to mix normal distributions
                          of the components.
 
-                         The type of the distribution model and the number of rows
-                         in \code{cmp} field will be as follows with this value:
-                         \itemize{
-                             \item \code{0} : Normal distribution.
-                                       \code{cmp} has only 1 row.
-                             \item \code{1} : Mean of 2 normal distributions.
-                                       \code{cmp} has 2 rows.
-                             \item \code{2} : Horizontal gradational distribution.
-                                       \code{cmp} has 2 rows.
-                             \item \code{3} : Vertical gradational distribution.
-                                       \code{cmp} has 2 or 3 rows.
-                             \item \code{4} : Horizontal-vertical gradational distribution.
-                                              \code{cmp} has 4 rows.
-                         }
+         The type of the distribution model and the number of components,
+         which equals the number of rows in \code{cmp} field, will be as follows.
 
-                         The distribution model of \code{mix.type = 1} is not
-                         a gradational Gaussian distribution (GGD), but a kind of
-                         Gaussian mixture model (GMM).
-                         This is provided for comparing GGD with GMM.}
+         \tabular{clc}{
+             \code{mix.type} \tab Distribution model          \tab Number of components \cr
+             \code{0}        \tab Normal distribution                            \tab 1 \cr
+             \code{1}        \tab Mean of 2 normal distributions                 \tab 2 \cr
+             \code{2}        \tab Horizontal gradational distribution (default)  \tab 2 \cr
+             \code{3}        \tab Vertical gradational distribution          \tab 2 or 3 \cr
+             \code{4}        \tab Horizontal-vertical gradational distribution   \tab 4
+         }
+
+         The distribution model of \code{mix.type = 1} is not
+         a gradational Gaussian distribution (GGD), but a kind of
+         Gaussian mixture model (GMM). This is provided for comparing GGD with GMM.}
 
 \item{\code{cmp}}{A data frame with 2 numeric columns which have
                          the parameters of the normal distributions of the components.
 
-                         \code{mean} column represents the mean values of the components,
-                         and \code{sd} column represents the standard deviations.
+         \code{mean} column represents the mean values of the components,
+         and \code{sd} column represents the standard deviations.
 
-                         Where \code{mix.type} is from \code{0} to \code{3},
-                         it has 1 to 3 rows named like \code{"n.i"}.
-                         Where \code{mix.type = 4},
-                         it has 4 rows named like \code{"n.i.j"}.}
+         Where \code{mix.type} is from \code{0} to \code{3},
+         it has 1 to 3 rows named like \code{"n.i"}.
+         Where \code{mix.type = 4}, it has 4 rows named like \code{"n.i.j"}.}
 
 \item{\code{median}}{A numeric; the median of the distribution.}
 
@@ -264,11 +301,10 @@ the estimated modulus of the absolute error for \code{lsd}.}
 \item{\code{usd.abs.error}}{A numeric;
                          the estimated modulus of the absolute error for \code{usd}.
 
-                         Where \code{mix.type = 4}, to compute the half standard deviations,
-                         \code{\link[stats]{integrate}} function is used.
-                         And the modulus of the absolute errors which
-                         \code{\link[stats]{integrate}} function has reported
-                         will be set into these \code{*.abs.error} fields.}
+         Where \code{mix.type = 4}, to compute the half standard deviations,
+         \code{\link[stats]{integrate}} function is used.
+         And the modulus of the absolute errors which \code{\link[stats]{integrate}}
+         function has reported will be set into these \code{*.abs.error} fields.}
 }}
 
 

--- a/man/GGD-class.Rd
+++ b/man/GGD-class.Rd
@@ -224,7 +224,7 @@ That is, the index number for the value of \code{kind} field.}
 
          \tabular{clc}{
              Index \tab Distribution model (\code{kind}) \cr
-             \code{1}  \tab Normal distribution \cr
+             \code{1}  \tab Normal Distribution \cr
              \code{2}  \tab
                  Mean of Mean-Differed Sigma-Equaled 2 Normal Distributions \cr
              \code{3}  \tab Mean of Mean-Equaled Sigma-Differed " \cr
@@ -243,7 +243,7 @@ That is, the index number for the value of \code{kind} field.}
              \code{14} \tab
                  Mean-Differed Sigma-Equaled Horizontal-Vertical Gradational Distribution \cr
              \code{15} \tab Mean-Equaled Sigma-Differed " \cr
-             \code{16} \tab Mean-Differed Sigma-Differed " \cr
+             \code{16} \tab Mean-Differed Sigma-Differed "
          }
 
          \code{kind.index} and \code{kind} fields represent how the object actually

--- a/man/adjust.cmp.rownames.Rd
+++ b/man/adjust.cmp.rownames.Rd
@@ -12,5 +12,5 @@ The adjusted \code{\link[ggd]{GGD}} object itself (invisible).
 }
 \description{
 Sets each row name of \code{cmp} field according to \code{mix.type} field.
-Normally, users of this class don't need to call this method directly.
+Normally, users of this class do not need to call this method directly.
 }

--- a/man/adjust.kind.index.Rd
+++ b/man/adjust.kind.index.Rd
@@ -13,5 +13,5 @@ The adjusted \code{\link[ggd]{GGD}} object itself (invisible).
 \description{
 Sets \code{kind.index} and \code{kind} fields according to
 \code{mix.type} and \code{cmp} fields.
-Normally, users of this class don't need to call this method directly.
+Normally, users of this class do not need to call this method directly.
 }

--- a/man/adjust.median.mean.sd.Rd
+++ b/man/adjust.median.mean.sd.Rd
@@ -14,5 +14,5 @@ The \code{\link[ggd]{GGD}} object itself (invisible).
 Calculates the median, the mean, and the standard deviation of the distribution model and
 then sets those values into the fields.
 Before calling this method, you must set \code{cmp} and \code{mix.type} fields.
-Normally, users of this class don't need to call this method directly.
+Normally, users of this class do not need to call this method directly.
 }

--- a/man/apply.cmp.Rd
+++ b/man/apply.cmp.Rd
@@ -13,7 +13,7 @@ If \code{NULL}, nothing is applied.}
 
 \item{f.sd}{A function to apply to elements in \code{sd} column.
 If \code{NULL}, nothing is applied.
-See 'Details' for more information.}
+See \sQuote{Details} for more information.}
 }
 \value{
 The processed \code{\link[ggd]{GGD}} object itself (invisible).
@@ -31,10 +31,10 @@ Each function indicated with \code{f.mean} or \code{f.sd} can receive
          \item The \code{\link[ggd]{GGD}} object itself.
      }
      Therefore, the function for \code{f.mean} or \code{f.cmp} is hoped to be
-     declared with 2 arguments like as '\code{function(mean, obj)}',
+     declared with 2 arguments like as \code{function(mean, obj)},
      however, if the function do not need the 2nd argument,
      you can declare with 1 arguments
-     like as '\code{function(mean)}' or '\code{function(sd)}'.
+     like as \code{function(mean)} or \code{function(sd)}.
      For the values of the functions, each function must return a numeric vector
      with the same length of the 1st argument as new values of each column.
 

--- a/man/calc.v.sub.Rd
+++ b/man/calc.v.sub.Rd
@@ -15,7 +15,8 @@ calc.v.sub(mix.type, mean, mean.i, sd.i, x, p.sum = 0, i = 0)
 
 \item{sd.i}{The standard deviation of the i-th normal distribution of the component.}
 
-\item{x}{The upper limit of the integral interval (see formulas in 'Details').}
+\item{x}{The upper limit of the integral interval
+(see formulas in \sQuote{Details}).}
 
 \item{p.sum}{The sum of the probabilities of two normal distributions of
 the components at \code{x = q}; the lower or upper limit of the domain
@@ -26,11 +27,11 @@ This argument is for \code{mix.type = 2}.}
 This argument is for \code{mix.type = 3}.}
 }
 \value{
-Calculated value of the expression shown in 'Details'.
+Calculated value of the expression shown in \sQuote{Details}.
 }
 \description{
 A sub-function of \code{\link[ggd]{calc.v}} where \code{mix.type} is \code{2} or \code{3}.
-The meaning of this function is depend on \code{mix.type} (see 'Details').
+The meaning of this function is depend on \code{mix.type} (see \sQuote{Details}).
 }
 \details{
 Depending on the value of \code{mix.type}, the following calculations are performed without

--- a/man/ggd.kind.index.Rd
+++ b/man/ggd.kind.index.Rd
@@ -11,8 +11,10 @@ ggd.kind.index(objs, undef.err = FALSE)
                      distribution model.
 
                      Each element must be a character string of a regular expression pattern
-                     matching to an element of \code{ggd:::kinds} or an index number of
-                     \code{ggd:::kinds}, or a \code{\link[ggd]{GGD}} object, or an \code{NA}.
+                     matching to an element of \code{ggd:::kinds}
+                     (see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}})
+                     or an index number of \code{ggd:::kinds},
+                     or a \code{\link[ggd]{GGD}} object, or an \code{NA}.
 
                      If a character string is indicated as an element,
                      the string matches only one element of \code{ggd:::kinds} of

--- a/man/ggd.kind.index.Rd
+++ b/man/ggd.kind.index.Rd
@@ -12,7 +12,7 @@ ggd.kind.index(objs, undef.err = FALSE)
 
                      Each element must be a character string of a regular expression pattern
                      matching to an element of \code{ggd:::kinds}
-                     (see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}})
+                     (see \code{kind} in \sQuote{Fields} at \code{\link[ggd]{GGD-class}})
                      or an index number of \code{ggd:::kinds},
                      or a \code{\link[ggd]{GGD}} object, or an \code{NA}.
 
@@ -23,7 +23,7 @@ ggd.kind.index(objs, undef.err = FALSE)
                      \code{ c(1L, 4L, 2L, 3L, 7L, 5L, 6L, 10L, 8L, 9L, 13L, 11L, 12L,
                               16L, 14L, 15L)}.
                      The order is designed for practical purposes so that
-                     the '\code{Mean-Differed Sigma-Differed}' model,
+                     the \code{"Mean-Differed Sigma-Differed"} model,
                      which has more degrees of freedom than the others of the same type,
                      can be matched first.
 

--- a/man/ggd.mix.type.for.Rd
+++ b/man/ggd.mix.type.for.Rd
@@ -44,7 +44,7 @@ An integer of \code{mix.type} value appropriate for a distribution model
          \code{integer(0)} is returned when \code{grad} is \code{"default"}.
 
          Although the length of \code{grad} argument must be 1 (or 0 as the default),
-         but lengths of other arguments are not checked in this function consciously.
+         the lengths of other arguments are not checked in this function consciously.
          So if \code{grad} is \code{"default"}, a vector of 2 or more length can be returned.
          That means, the length of other arguments or the return value must be checked
          by the caller of this function if necessary.

--- a/man/ggd.nls.freq.all.Rd
+++ b/man/ggd.nls.freq.all.Rd
@@ -118,7 +118,7 @@ A list containing components
 }
 \description{
 Approximates the given frequency distribution with all of distribution models
-available in this package (the number of models is 16), and compare their accuracies.
+available in this package (the number of models is 16), and compares their accuracies.
 The accuracy is checked by the correlation coefficients with the frequency distribution
 computed by \code{\link[stats]{cor}}.
 }

--- a/man/ggd.nls.freq.all.Rd
+++ b/man/ggd.nls.freq.all.Rd
@@ -57,7 +57,7 @@ See \code{\link[ggd]{nls.freq}} for more information.}
                  In addition, \code{\link[ggd]{ggd.kind}} and
                  \code{\link[ggd]{ggd.kind.index}} functions may help you whether
                  each index number of \code{start} represents what kind of distribution.
-                 See 'Examples' for usages of these tools.}
+                 See \sQuote{Examples} for usages of these tools.}
 
 \item{control}{The \code{control} argument for \code{\link[stats]{nls}}.
 See \code{\link[stats]{nls.control}} for more information.}
@@ -82,7 +82,7 @@ If \code{NULL}, it uses the default method of \code{\link[stats]{cor}}.
 See \code{\link[stats]{cor}} for more information.}
 
 \item{...}{Each argument for \code{\link[stats]{nls}} can be indicated.
-See 'Arguments' of \code{\link[stats]{nls}} for more information.}
+See \sQuote{Arguments} of \code{\link[stats]{nls}} for more information.}
 }
 \value{
 A list containing components
@@ -114,7 +114,7 @@ A list containing components
                  Normally, each element is a list of the output of
                  \code{\link[ggd]{nls.freq}}.
                  But if an error has occurred, the element will be an error condition.
-                 See 'Value' of \code{\link[ggd]{nls.freq}} for more information.}
+                 See \sQuote{Value} of \code{\link[ggd]{nls.freq}} for more information.}
 }
 \description{
 Approximates the given frequency distribution with all of distribution models
@@ -125,25 +125,25 @@ computed by \code{\link[stats]{cor}}.
 \details{
 The output lists are ordered by index number of \code{ggd:::kinds},
 which will be set into \code{kind.index} field of each object
-(see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}}).
+(see \code{kind} in \sQuote{Fields} at \code{\link[ggd]{GGD-class}}).
 
 This function generates 16 \code{\link[ggd]{GGD}} objects and
 calls \code{\link[ggd]{nls.freq}} method 16 times.
 By default, \code{\link[ggd]{nls.freq}} is called with \code{warnOnly = TRUE},
 so \code{\link[ggd]{nls.freq}} does not generate errors, but generates warnings often.
 When a warning occur, this function generates another warning like
-'\code{Warning for kind = xx :}' to inform which \code{kind.index} gets a poor result
+\code{"Warning for kind = xx :"} to inform which \code{kind.index} gets a poor result
 (poor, but may be accurate enough).
 So when one warning has occurred, two warnings will occur eventually.
 
 If you indicate \code{warnOnly = FALSE} in \code{control} argument
 and overwrite \code{warnOnly} option, \code{\link[ggd]{nls.freq}} can generate errors.
 If an error occurs in one of \code{\link[ggd]{nls.freq}} processes,
-this function throws messages like '\code{Error for kind = xx :}' and '\code{Error in ...}'
+this function throws messages like \code{"Error for kind = xx :"} and \code{"Error in ..."}
 instead of throwing an error and skips the process,
 then tries other \code{\link[ggd]{nls.freq}} processes.
 For the result of error-occurred \code{kind.index}, a cleared \code{\link[ggd]{GGD}} object
-will be got as the element of \code{obj} (see 'Value').
+will be got as the element of \code{obj} (see \sQuote{Value}).
 }
 \examples{
  ## Preparing:

--- a/man/ggd.nls.freq.all.Rd
+++ b/man/ggd.nls.freq.all.Rd
@@ -123,27 +123,9 @@ The accuracy is checked by the correlation coefficients with the frequency distr
 computed by \code{\link[stats]{cor}}.
 }
 \details{
-The output lists are ordered by \code{ggd:::kinds} as:
-\enumerate{
-     \item   Normal Distribution
-     \item   Mean of Mean-Differed Sigma-Equaled 2 Normal Distributions
-     \item   Mean of Mean-Equaled Sigma-Differed 2 Normal Distributions
-     \item   Mean of Mean-Differed Sigma-Differed 2 Normal Distributions
-     \item   Mean-Differed Sigma-Equaled Horizontal Gradational Distribution
-     \item   Mean-Equaled Sigma-Differed Horizontal Gradational Distribution
-     \item   Mean-Differed Sigma-Differed Horizontal Gradational Distribution
-     \item   2-Mean-Differed Sigma-Equaled Vertical Gradational Distribution
-     \item   2-Mean-Equaled Sigma-Differed Vertical Gradational Distribution
-     \item   2-Mean-Differed Sigma-Differed Vertical Gradational Distribution
-     \item   3-Mean-Differed Sigma-Equaled Vertical Gradational Distribution
-     \item   3-Mean-Equaled Sigma-Differed Vertical Gradational Distribution
-     \item   3-Mean-Differed Sigma-Differed Vertical Gradational Distribution
-     \item   Mean-Differed Sigma-Equaled Horizontal-Vertical Gradational Distribution
-     \item   Mean-Equaled Sigma-Differed Horizontal-Vertical Gradational Distribution
-     \item   Mean-Differed Sigma-Differed Horizontal-Vertical Gradational Distribution
-}
-Each index number of above list is
-also set into \code{kind.index} field of each \code{\link[ggd]{GGD}} object.
+The output lists are ordered by index number of \code{ggd:::kinds},
+which will be set into \code{kind.index} field of each object
+(see \code{kind} in 'Fields' at \code{\link[ggd]{GGD-class}}).
 
 This function generates 16 \code{\link[ggd]{GGD}} objects and
 calls \code{\link[ggd]{nls.freq}} method 16 times.

--- a/man/is.eq.mean.Rd
+++ b/man/is.eq.mean.Rd
@@ -13,7 +13,7 @@
 }
 \description{
 Checks if the mean values of all normal distributions of components are equal.
-The equality is determined by the '\code{==}' operator.
+The equality is determined by the \code{\link[base]{==}} operator.
 }
 \examples{
  a <- GGD$new()

--- a/man/is.eq.sd.Rd
+++ b/man/is.eq.sd.Rd
@@ -17,7 +17,7 @@
 }
 \description{
 Checks if the standard deviations of all normal distributions of components are equal.
-The equality is determined by the '\code{==}' operator.
+The equality is determined by the \code{\link[base]{==}} operator.
 }
 \examples{
  a <- GGD$new()

--- a/man/nls.freq.Rd
+++ b/man/nls.freq.Rd
@@ -233,7 +233,7 @@ See \sQuote{Arguments} of \code{\link[stats]{nls}} for more information.}
                      and \code{grad} argument is \code{"default"},
                      the current value of \code{mix.type} field will be retained,
                      and number of components will also.
-                     However, if the object has been cleared when this method is called,
+                     But note if the object has been cleared when this method is called,
                      \code{mix.type} field will be \code{2}, the start value.}
 }
 \value{

--- a/man/nls.freq.Rd
+++ b/man/nls.freq.Rd
@@ -206,7 +206,7 @@ This argument works only if \code{start.level = 100}.
 See \code{\link[stats]{cor}} for more information.}
 
 \item{...}{Each argument for \code{\link[stats]{nls}} can be indicated.
-See 'Arguments' of \code{\link[stats]{nls}} for more information.}
+See \sQuote{Arguments} of \code{\link[stats]{nls}} for more information.}
 
 \item{this.kind}{A character string or a numeric value or a \code{\link[ggd]{GGD}} object
                      which indicates the kind of distribution model to be constructed.
@@ -247,7 +247,7 @@ A list containing components (invisible for \code{GGD} method)
          \item{nls.out}{
                  The list of the output of \code{\link[stats]{nls}}.
                  If \code{\link[stats]{nls}} has not been used, \code{NULL} will be set.
-                 See 'Value' of \code{\link[stats]{nls}} for more information.}
+                 See \sQuote{Value} of \code{\link[stats]{nls}} for more information.}
          \item{start.level}{
                  The initial guessing level which is used actually to obtain \code{obj}.
                  If \code{start.level = 100} is indicated,
@@ -289,13 +289,13 @@ constructs a \code{\link[ggd]{GGD}} object which (locally) most closely approxim
 the given frequency distribution.
 Then \code{ggd.nls.freq} function generates a \code{\link[ggd]{GGD}} object,
 and \code{nls.freq} method sets the fields according to the result.
-'Locally' means that if the start value is modified, more closely approximating model
+\sQuote{Locally} means that if the start value is modified, more closely approximating model
 may be constructed.
 The outliers of the frequency distribution will not be excluded in this function.
 If necessary, outliers should be excluded by preprocessing.
 }
 \details{
-\subsection{Why the standard deviations for 'start' are square-rooted?}{
+\subsection{Why the standard deviations for start are square-rooted?}{
      You know a standard deviation must be a positive value.
      But if you use standard deviations directly in the formula for \code{\link[stats]{nls}},
      they sometimes drop into negative values while the Gauss-Newton algorithm is running

--- a/man/nls.freq.Rd
+++ b/man/nls.freq.Rd
@@ -76,7 +76,7 @@ ggd.nls.freq(data, x = "x", freq = "freq", total = NULL,
                          \item 1: Mean of 2 normal distributions.
                          \item 2: Horizontal gradation of 2 normal distributions.
                          \item 3: Vertical gradation of 2 (or 3) normal distributions.
-                         \item 4: Horizontal-Vertical gradation
+                         \item 4: Horizontal-vertical gradation
                                   with 4 (2x2) normal distributions.
                      }
 

--- a/man/nls.freq.level.100.Rd
+++ b/man/nls.freq.level.100.Rd
@@ -43,7 +43,7 @@ See \code{\link[stats]{nls.control}} for more information.}
 \item{cor.method}{The \code{method} argument for \code{\link[stats]{cor}}.}
 
 \item{...}{Each argument for \code{\link[stats]{nls}} can be indicated.
-See 'Arguments' of \code{\link[stats]{nls}} for more information.}
+See \sQuote{Arguments} of \code{\link[stats]{nls}} for more information.}
 }
 \value{
 A list conforming the return value of \code{\link[ggd]{nls.freq}}.

--- a/man/set.cmp.Rd
+++ b/man/set.cmp.Rd
@@ -70,7 +70,8 @@ ggd.set.cmp(cmp, kind = NULL, mix.type = NULL,
                      Numberless \code{"v"} is an alias for \code{"v2"}.
 
                      \code{"normal"} is for a normal distribution,
-                     then also, \code{'grad = "no"'} can be read as 'no gradation'.
+                     then also, \sQuote{\code{grad = "no"}} can be read as
+                     \sQuote{no gradation}.
 
                      \code{"default"} is, if \code{kind} or \code{mix.type} argument
                      is given, follows it, otherwise it depends on the number of columns
@@ -100,7 +101,7 @@ Whenever you want to set values in \code{cmp} field, it is strongly recommended 
 this method.
 }
 \details{
-\subsection{About 'kind' and 'mix.type'}{
+\subsection{About kind and mix.type}{
      In this function,
      unlike \code{\link[ggd]{trace.q}} and \code{\link[ggd]{nls.freq}} methods,
      \code{[this.]kind} argument is only used to determine \code{mix.type} value,

--- a/man/set.cmp.Rd
+++ b/man/set.cmp.Rd
@@ -43,16 +43,13 @@ ggd.set.cmp(cmp, kind = NULL, mix.type = NULL,
 
                      The type of the distribution model and the number of rows in \code{cmp}
                      follow \code{mix.type} as:
-                     \itemize{
-                         \item \code{0} : Normal distribution. \code{cmp} has only 1 row.
-                         \item \code{1} : Mean of 2 normal distributions.
-                                          \code{cmp} has 2 rows.
-                         \item \code{2} : Horizontal gradational distribution.
-                                          \code{cmp} has 2 rows.
-                         \item \code{3} : Vertical gradational distribution.
-                                          \code{cmp} has 2 or 3 rows.
-                         \item \code{4} : Horizontal-vertical gradational distribution.
-                                          \code{cmp} has 4 rows.
+                     \tabular{clc}{
+                         \code{mix.type} \tab Distribution model     \tab Number of rows \cr
+                         \code{0} \tab Normal distribution                   \tab 1 \cr
+                         \code{1} \tab Mean of 2 normal distributions        \tab 2 \cr
+                         \code{2} \tab Horizontal gradational distribution   \tab 2 \cr
+                         \code{3} \tab Vertical gradational distribution     \tab 2 or 3 \cr
+                         \code{4} \tab Horizontal-vertical gradational distribution  \tab 4
                      }
 
                      If the number of rows in \code{cmp} argument is different from

--- a/man/tex.Rd
+++ b/man/tex.Rd
@@ -24,17 +24,17 @@
 \arguments{
 \item{con}{A \code{\link[base]{connection}} object or a character string
 to indicate the output destination.
-See 'Details' at \code{\link[base]{writeLines}}
+See \sQuote{Details} at \code{\link[base]{writeLines}}
 for more information.}
 
 \item{sep}{A character string to be written to the connection after each line
-of text. See 'Details' at \code{\link[base]{writeLines}}
+of text. See \sQuote{Details} at \code{\link[base]{writeLines}}
 for more information.}
 
-\item{comma}{A logical. If \code{TRUE}, this method writes a ',' (comma)
-as a separator between each expression and a '.' (period)
+\item{comma}{A logical. If \code{TRUE}, this method writes a \sQuote{,} (comma)
+as a separator between each expression and a \sQuote{.} (period)
 at the end of the output.
-If \code{FALSE}, those ',' and '.' will not be written.}
+If \code{FALSE}, those \sQuote{,} and \sQuote{.} will not be written.}
 
 \item{format.num}{A function to format each numeric value of mean values and
 standard deviations.
@@ -77,17 +77,17 @@ using \code{\link[base]{writeLines}}.
  \subsection{Equaled mean values or standard deviations}{
      For clarity, when all mean values or standard deviations of components are equal
      (i.e., when \code{\link[ggd]{is.eq.mean}} or \code{\link[ggd]{is.eq.sd}} method
-     returns \code{TRUE}), they are displayed with '\eqn{=}' to the 1st parameter,
-     like as '\eqn{\sigma_2 = \sigma_1}'.
+     returns \code{TRUE}), they are displayed with \sQuote{\eqn{=}} to the 1st parameter,
+     like as \sQuote{\eqn{\sigma_2 = \sigma_1}}.
 
      If only the values of some parameters are equal (e.g., only \eqn{\sigma_2} and
      \eqn{\sigma_3} are equal and \eqn{\sigma_1} is different),
-     each value is displayed as '\eqn{\sigma_2 = x, \sigma_3 = x}'
-     instead of '\eqn{\sigma_3 = \sigma_2}' to avoid misreading.
+     each value is displayed as \sQuote{\eqn{\sigma_2 = x, \sigma_3 = x}}
+     instead of \sQuote{\eqn{\sigma_3 = \sigma_2}} to avoid misreading.
 
      Note that if the difference between the values of parameters is smaller than
-     displayable number of decimal places, '\eqn{\sigma_2 = \sigma_1}' will not be displayed,
-     but the same number will be displayed for each.
+     displayable number of decimal places, \sQuote{\eqn{\sigma_2 = \sigma_1}}
+     will not be displayed, but the same number will be displayed for each.
  }
 }
 \examples{

--- a/man/trace.q.Rd
+++ b/man/trace.q.Rd
@@ -63,7 +63,7 @@ ggd.trace.q(quantiles, x = "x", p = "p",
                          \item \code{2} : Horizontal gradation of 2 normal distributions.
                          \item \code{3} : Vertical gradation of 2 or 3 normal distributions.
                                           The 2-component model has priority.
-                         \item \code{4} : Horizontal-Vertical gradation
+                         \item \code{4} : Horizontal-vertical gradation
                                           with 4 (2x2) normal distributions.
                      }
                      If \code{NULL}

--- a/man/trace.q.Rd
+++ b/man/trace.q.Rd
@@ -95,7 +95,7 @@ ggd.trace.q(quantiles, x = "x", p = "p",
                      to be equal.
                      This condition reduces the degrees of freedom,
                      so allowed number of quantiles will be restricted.
-                     See 'Details' for more information.
+                     See \sQuote{Details} for more information.
 
                      If \code{FALSE}, the mean values are not bound,
                      and mean-equaled components will be rarely constructed.
@@ -115,7 +115,7 @@ ggd.trace.q(quantiles, x = "x", p = "p",
                      the components to be equal.
                      This condition reduces the degrees of freedom,
                      so allowed number of quantiles will be restricted.
-                     See 'Details' for more information.
+                     See \sQuote{Details} for more information.
 
                      If \code{FALSE} or \code{logical(0)},
                      the standard deviations are not bound,

--- a/man/write.csv.Rd
+++ b/man/write.csv.Rd
@@ -29,7 +29,7 @@ regardless of the package version or R version.
      Mean values and standard deviations are recorded to a maximum length of
      the 22nd decimal place.
      The accuracy is sufficient to reconstruct the original object almost completely
-     (at least the value of each field can be \code{TRUE} with '\code{==}')
+     (at least the value of each field can be \code{TRUE} with \code{\link[base]{==}})
      in most cases, and in most systems.
 }
 }


### PR DESCRIPTION
Updated manuals.
+ Description about 'kind' is  now consolidated in 'Fields' at 'GGD-class'.
+ Tables are now adopted to explain 'mix.type' and 'kind'.
+ Single quotation marks were replaced to \sQuote.
+ Added link from '==' operator to base::Comparison.
+ Corrected some words and phrases.